### PR TITLE
Fix TypeScript config for test environment

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,10 @@
         "lib": [
             "ES2022"
         ],
+        "types": [
+            "node",
+            "mocha"
+        ],
         "sourceMap": true,
         "rootDir": "src",
         "strict": true,


### PR DESCRIPTION
## Summary
- add mocha and node type definitions to tsconfig for tests

## Testing
- `npm test` *(fails: Missing X server or DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_6843d29e66e48325abdd4830acd2ed96