### PR TITLE
Fix alphabetical sort in conflict detection

### DIFF
--- a/src/dependencyTreeService.ts
+++ b/src/dependencyTreeService.ts
@@ -262,8 +262,12 @@ export class DependencyTreeService {
         // Check for conflicts (multiple versions of the same module)
         for (const [moduleName, versions] of versionMap.entries()) {
             if (versions.size > 1) {
-                const versionList = Array.from(versions).sort().join(', ');
-                conflicts.push(`${moduleName}: Multiple versions found (${versionList})`);
+                const versionList = Array.from(versions)
+                    .sort((a, b) => a.localeCompare(b))
+                    .join(', ');
+                conflicts.push(
+                    `${moduleName}: Multiple versions found (${versionList})`
+                );
             }
         }
 


### PR DESCRIPTION
## Summary
- enforce locale-aware sorting for detected version conflicts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843ec10f9e4832580058e10c1e83889