### PR TITLE
Add caching layer with clear command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       run: npm run compile
 
     - name: Run tests
-      run: xvfb-run -a npm test
+      run: npm test
 
     - name: Upload test results
       uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ Run tests with: `npm test`
 ### Puppet Forge API
 - Uses the official Puppet Forge API v3
 - Respects rate limits and implements proper error handling
-- Caches responses for improved performance
-- Cache can be cleared via the **Clear Puppet Forge cache** command
+ - Caches responses for improved performance
+ - Cache can be cleared via the **Clear Puppet Forge cache** command (also available from the Puppetfile context menu)
 - Falls back gracefully when API is unavailable
 
 ### Network Requirements

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Run tests with: `npm test`
 - Uses the official Puppet Forge API v3
 - Respects rate limits and implements proper error handling
 - Caches responses for improved performance
+- Cache can be cleared via the **Clear Puppet Forge cache** command
 - Falls back gracefully when API is unavailable
 
 ### Network Requirements

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
         "command": "puppetfile-depgraph.showDependencyTree",
         "title": "Show dependency tree",
         "category": "Puppetfile"
+      },
+      {
+        "command": "puppetfile-depgraph.clearForgeCache",
+        "title": "Clear Puppet Forge cache",
+        "category": "Puppetfile"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
           "when": "resourceFilename == Puppetfile",
           "command": "puppetfile-depgraph.showDependencyTree",
           "group": "navigation"
+        },
+        {
+          "when": "resourceFilename == Puppetfile",
+          "command": "puppetfile-depgraph.clearForgeCache",
+          "group": "navigation"
         }
       ]
     }
@@ -60,7 +65,7 @@
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
-    "test": "vscode-test"
+    "test": "node ./scripts/runTests.js"
   },
   "devDependencies": {
     "@types/vscode": "^1.100.0",

--- a/scripts/runTests.js
+++ b/scripts/runTests.js
@@ -1,0 +1,8 @@
+const { spawnSync } = require('child_process');
+
+const isWin = process.platform === 'win32';
+const cmd = isWin ? 'npx' : 'xvfb-run';
+const args = isWin ? ['vscode-test'] : ['-a', 'npx', 'vscode-test'];
+
+const result = spawnSync(cmd, args, { stdio: 'inherit', shell: true });
+process.exit(result.status ?? 1);

--- a/scripts/runTests.js
+++ b/scripts/runTests.js
@@ -1,8 +1,8 @@
 const { spawnSync } = require('child_process');
 
 const isWin = process.platform === 'win32';
-const cmd = isWin ? 'npx' : 'xvfb-run';
+const cmd = isWin ? 'npx.cmd' : 'xvfb-run';
 const args = isWin ? ['vscode-test'] : ['-a', 'npx', 'vscode-test'];
 
-const result = spawnSync(cmd, args, { stdio: 'inherit', shell: true });
+const result = spawnSync(cmd, args, { stdio: 'inherit' });
 process.exit(result.status ?? 1);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { PuppetfileParser, PuppetModule } from './puppetfileParser';
 import { PuppetfileUpdateService } from './puppetfileUpdateService';
 import { DependencyTreeService } from './dependencyTreeService';
 import { PuppetfileHoverProvider } from './puppetfileHoverProvider';
+import { PuppetForgeService } from './puppetForgeService';
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -93,8 +94,8 @@ export function activate(context: vscode.ExtensionContext) {
 		});
 	});
 
-	const showDependencyTree = vscode.commands.registerCommand('puppetfile-depgraph.showDependencyTree', async () => {
-		const parseResult = PuppetfileParser.parseActiveEditor();
+        const showDependencyTree = vscode.commands.registerCommand('puppetfile-depgraph.showDependencyTree', async () => {
+                const parseResult = PuppetfileParser.parseActiveEditor();
 		if (parseResult.errors.length > 0) {
 			vscode.window.showErrorMessage(`Puppetfile parsing errors: ${parseResult.errors.join(', ')}`);
 			return;
@@ -165,11 +166,16 @@ export function activate(context: vscode.ExtensionContext) {
 			} catch (error) {
 				vscode.window.showErrorMessage(`Failed to build dependency tree: ${error instanceof Error ? error.message : 'Unknown error'}`);
 			}
-		});
-	});
+                });
+        });
 
-	// Add all commands to subscriptions
-	context.subscriptions.push(updateAllToSafe, updateAllToLatest, showDependencyTree);
+        const clearForgeCache = vscode.commands.registerCommand('puppetfile-depgraph.clearForgeCache', () => {
+                PuppetForgeService.clearCache();
+                vscode.window.showInformationMessage('Puppet Forge cache cleared.');
+        });
+
+        // Add all commands to subscriptions
+        context.subscriptions.push(updateAllToSafe, updateAllToLatest, showDependencyTree, clearForgeCache);
 
 	// Register hover provider for Puppetfile (pattern-based to avoid duplicates)
 	const hoverProvider = vscode.languages.registerHoverProvider(

--- a/src/test/puppetForgeService.test.ts
+++ b/src/test/puppetForgeService.test.ts
@@ -38,6 +38,15 @@ suite('PuppetForgeService Test Suite', () => {
         assert.strictEqual(PuppetForgeService.isSafeVersion('1.0.0-snapshot'), false);
     });
 
+    test('clearCache should empty internal caches', () => {
+        const svc: any = PuppetForgeService;
+        svc.moduleCache.set('foo', { data: null, timestamp: Date.now() });
+        svc.releaseCache.set('foo', { data: [], timestamp: Date.now() });
+        PuppetForgeService.clearCache();
+        assert.strictEqual(svc.moduleCache.size, 0);
+        assert.strictEqual(svc.releaseCache.size, 0);
+    });
+
     // Note: These tests require network access and may be slow
     // In a real-world scenario, you might want to mock these API calls
     test('getModule should handle non-existent modules gracefully', async function() {

--- a/src/test/puppetForgeService.test.ts
+++ b/src/test/puppetForgeService.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import { PuppetForgeService } from '../puppetForgeService';
+import pkg from '../../package.json';
 
 suite('PuppetForgeService Test Suite', () => {
     
@@ -40,8 +41,9 @@ suite('PuppetForgeService Test Suite', () => {
 
     test('clearCache should empty internal caches', () => {
         const svc: any = PuppetForgeService;
-        svc.moduleCache.set('foo', { data: null, timestamp: Date.now() });
-        svc.releaseCache.set('foo', { data: [], timestamp: Date.now() });
+        const key = `foo@${pkg.version}`;
+        svc.moduleCache.set(key, null);
+        svc.releaseCache.set(key, []);
         PuppetForgeService.clearCache();
         assert.strictEqual(svc.moduleCache.size, 0);
         assert.strictEqual(svc.releaseCache.size, 0);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
         "strict": true,
         "moduleResolution": "Node16",
         "esModuleInterop": true,
+        "resolveJsonModule": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true
         /* Additional Checks */


### PR DESCRIPTION
## Summary
- implement an in-memory cache in `PuppetForgeService`
- expose command to clear the cache from the command palette
- document cache clearing in README
- test cache clearing

## Testing
- `npm run lint`
- `npm run compile`
- `npm test` *(fails: cannot run VS Code in test env)*

------
https://chatgpt.com/codex/tasks/task_e_684454b7029c83258518ce67d967791f