### PR TITLE
Fix Puppet Forge links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "puppetfile-depgraph",
       "version": "0.0.1",
       "dependencies": {
-        "axios": "^1.7.9"
+        "axios": "^1.7.9",
+        "https-proxy-agent": "^7.0.6"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
@@ -686,7 +687,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -1096,7 +1096,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1847,7 +1846,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -2469,8 +2467,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@vscode/test-electron": "^2.5.2"
   },
   "dependencies": {
-    "axios": "^1.7.9"
+    "axios": "^1.7.9",
+    "https-proxy-agent": "^7.0.6"
   }
 }

--- a/src/puppetForgeService.ts
+++ b/src/puppetForgeService.ts
@@ -65,7 +65,7 @@ export class PuppetForgeService {
             }
         };
 
-        const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+        const proxyUrl = process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY;
         if (proxyUrl) {
             const agent = new HttpsProxyAgent(proxyUrl);
             options.httpAgent = agent;
@@ -137,7 +137,7 @@ export class PuppetForgeService {
                     }
                 }
             );
-            const result = response.data.results || [];
+            const result = response.data.results ?? [];
             this.releaseCache.set(key, result);
             return result;
         } catch (error) {
@@ -157,7 +157,7 @@ export class PuppetForgeService {
     public static async getLatestVersion(moduleName: string): Promise<string | null> {
         try {
             const module = await this.getModule(moduleName);
-            return module?.current_release?.version || null;
+            return module?.current_release?.version ?? null;
         } catch (error) {
             console.error(`Error fetching latest version for ${moduleName}:`, error);
             return null;
@@ -203,8 +203,8 @@ export class PuppetForgeService {
         
         const maxLength = Math.max(parts1.length, parts2.length);
           for (let i = 0; i < maxLength; i++) {
-            const part1 = parts1[i] || 0;
-            const part2 = parts2[i] || 0;
+            const part1 = parts1[i] ?? 0;
+            const part2 = parts2[i] ?? 0;
             
             if (part1 < part2) {
                 return -1;

--- a/src/puppetForgeService.ts
+++ b/src/puppetForgeService.ts
@@ -57,7 +57,7 @@ export class PuppetForgeService {
     private static moduleCache: Map<string, ForgeModule | null> = new Map();
     private static releaseCache: Map<string, ForgeVersion[]> = new Map();
 
-    private static getAxiosOptions(url: string): AxiosRequestConfig {
+    private static getAxiosOptions(): AxiosRequestConfig {
         const options: AxiosRequestConfig = {
             timeout: 10000,
             headers: {
@@ -101,7 +101,7 @@ export class PuppetForgeService {
         try {
             const response = await axios.get(
                 `${this.BASE_URL}/${this.API_VERSION}/modules/${moduleName}`,
-                this.getAxiosOptions(`${this.BASE_URL}/${this.API_VERSION}/modules/${moduleName}`)
+                this.getAxiosOptions()
             );
             this.moduleCache.set(key, response.data);
             return response.data;
@@ -129,7 +129,7 @@ export class PuppetForgeService {
             const response = await axios.get(
                 `${this.BASE_URL}/${this.API_VERSION}/modules/${moduleName}/releases`,
                 {
-                    ...this.getAxiosOptions(`${this.BASE_URL}/${this.API_VERSION}/modules/${moduleName}/releases`),
+                    ...this.getAxiosOptions(),
                     params: {
                         limit: 100,
                         sort_by: 'version',

--- a/src/puppetForgeService.ts
+++ b/src/puppetForgeService.ts
@@ -1,5 +1,6 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import pkg from '../package.json';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 /**
  * Represents version information from Puppet Forge
@@ -56,6 +57,24 @@ export class PuppetForgeService {
     private static moduleCache: Map<string, ForgeModule | null> = new Map();
     private static releaseCache: Map<string, ForgeVersion[]> = new Map();
 
+    private static getAxiosOptions(url: string): AxiosRequestConfig {
+        const options: AxiosRequestConfig = {
+            timeout: 10000,
+            headers: {
+                'User-Agent': 'VSCode-Puppetfile-DepGraph/1.0.0'
+            }
+        };
+
+        const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+        if (proxyUrl) {
+            const agent = new HttpsProxyAgent(proxyUrl);
+            options.httpAgent = agent;
+            options.httpsAgent = agent;
+            options.proxy = false;
+        }
+        return options;
+    }
+
     private static cacheKey(name: string): string {
         return `${name}@${this.EXT_VERSION}`;
     }
@@ -82,12 +101,7 @@ export class PuppetForgeService {
         try {
             const response = await axios.get(
                 `${this.BASE_URL}/${this.API_VERSION}/modules/${moduleName}`,
-                {
-                    timeout: 10000,
-                    headers: {
-                        'User-Agent': 'VSCode-Puppetfile-DepGraph/1.0.0'
-                    }
-                }
+                this.getAxiosOptions(`${this.BASE_URL}/${this.API_VERSION}/modules/${moduleName}`)
             );
             this.moduleCache.set(key, response.data);
             return response.data;
@@ -115,10 +129,7 @@ export class PuppetForgeService {
             const response = await axios.get(
                 `${this.BASE_URL}/${this.API_VERSION}/modules/${moduleName}/releases`,
                 {
-                    timeout: 10000,
-                    headers: {
-                        'User-Agent': 'VSCode-Puppetfile-DepGraph/1.0.0'
-                    },
+                    ...this.getAxiosOptions(`${this.BASE_URL}/${this.API_VERSION}/modules/${moduleName}/releases`),
                     params: {
                         limit: 100,
                         sort_by: 'version',

--- a/src/puppetfileHoverProvider.ts
+++ b/src/puppetfileHoverProvider.ts
@@ -192,7 +192,7 @@ export class PuppetfileHoverProvider implements vscode.HoverProvider {
     }
 
     private getForgeModuleUrl(module: PuppetModule, forgeData?: ForgeModule | null): string {
-        if (forgeData && forgeData.owner && forgeData.name) {
+        if (forgeData?.owner?.username && forgeData.name) {
             return `https://forge.puppet.com/modules/${forgeData.owner.username}/${forgeData.name}`;
         }
 

--- a/src/puppetfileHoverProvider.ts
+++ b/src/puppetfileHoverProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { PuppetfileParser, PuppetModule } from './puppetfileParser';
-import { PuppetForgeService } from './puppetForgeService';
+import { PuppetForgeService, ForgeModule } from './puppetForgeService';
 
 /**
  * Provides hover information for Puppetfile modules
@@ -129,7 +129,8 @@ export class PuppetfileHoverProvider implements vscode.HoverProvider {
             }
 
             // Actions
-            markdown.appendMarkdown(`[View on Puppet Forge](https://forge.puppet.com/${module.name.replace('/', '-')})`);
+            const forgeUrl = this.getForgeModuleUrl(module, forgeModule);
+            markdown.appendMarkdown(`[View on Puppet Forge](${forgeUrl})`);
 
             return markdown;
 
@@ -176,7 +177,8 @@ export class PuppetfileHoverProvider implements vscode.HoverProvider {
 
         if (module.source === 'forge') {
             markdown.appendMarkdown(`*Loading additional information...*\n\n`);
-            markdown.appendMarkdown(`[View on Puppet Forge](https://forge.puppet.com/${module.name.replace('/', '-')})`);
+            const forgeUrl = this.getForgeModuleUrl(module);
+            markdown.appendMarkdown(`[View on Puppet Forge](${forgeUrl})`);
         } else if (module.gitUrl) {
             markdown.appendMarkdown(`**Repository:** [${module.gitUrl}](${module.gitUrl})\n\n`);
             if (module.gitTag) {
@@ -188,4 +190,24 @@ export class PuppetfileHoverProvider implements vscode.HoverProvider {
 
         return markdown;
     }
+
+    private getForgeModuleUrl(module: PuppetModule, forgeData?: ForgeModule | null): string {
+        if (forgeData && forgeData.owner && forgeData.name) {
+            return `https://forge.puppet.com/modules/${forgeData.owner.username}/${forgeData.name}`;
+        }
+
+        if (module.name.includes('/')) {
+            return `https://forge.puppet.com/modules/${module.name}`;
+        }
+
+        const dashIndex = module.name.indexOf('-');
+        if (dashIndex !== -1) {
+            const owner = module.name.substring(0, dashIndex);
+            const modName = module.name.substring(dashIndex + 1);
+            return `https://forge.puppet.com/modules/${owner}/${modName}`;
+        }
+
+        return `https://forge.puppet.com/modules/${module.name}`;
+    }
 }
+

--- a/src/puppetfileUpdateService.ts
+++ b/src/puppetfileUpdateService.ts
@@ -239,7 +239,7 @@ export class PuppetfileUpdateService {
         if (upToDate.length > 0) {
             summary += `✨ Already up-to-date (${upToDate.length}):\n`;
             for (const result of upToDate) {
-                summary += `  • ${result.moduleName}: ${result.currentVersion || 'latest'}\n`;
+                summary += `  • ${result.moduleName}: ${result.currentVersion ?? 'latest'}\n`;
             }
             summary += '\n';
         }


### PR DESCRIPTION
## Summary
- link to the Forge with owner/name path
- craft URLs with a helper using Forge API data when available
- support HTTPS_PROXY/HTTP_PROXY for Forge API requests

## Testing
- `npm run compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844833b7efc8325a51c34d8c504368e