### PR TITLE
Enhance hover with clickable versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "puppetfile-depgraph" extension will be documented in this file.
 
+## [0.0.2] - 2025-06-08
+### Added
+- Hover window now lists all newer versions with clickable links to update the Puppetfile.
+### Fixed
+- Dependency information and Forge links in the hover window now reference the current module version.
+
 ## [0.0.1] - 2025-06-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A comprehensive VS Code extension for managing Puppet module dependencies with v
 - Version comparison (current vs. latest available)
 - Dependency information
 - Direct links to Puppet Forge pages
+- Clickable list of newer versions for quick updates
 - Git repository information for Git-based modules
 
 ### 🎯 **Context Menu Integration**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "puppetfile-depgraph",
   "displayName": "Puppetfile Dependency Manager",
   "description": "A VS Code extension for managing Puppet module dependencies with visual dependency analysis and safe update recommendations",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "engines": {
     "vscode": "^1.100.0"
   },
@@ -41,6 +41,11 @@
       {
         "command": "puppetfile-depgraph.clearForgeCache",
         "title": "Clear Puppet Forge cache",
+        "category": "Puppetfile"
+      },
+      {
+        "command": "puppetfile-depgraph.updateModuleVersion",
+        "title": "Update module to specific version",
         "category": "Puppetfile"
       }
     ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,8 +174,15 @@ export function activate(context: vscode.ExtensionContext) {
                 vscode.window.showInformationMessage('Puppet Forge cache cleared.');
         });
 
+        const updateModuleVersion = vscode.commands.registerCommand('puppetfile-depgraph.updateModuleVersion', async (args: { line: number; version: string }) => {
+                if (!args) {
+                        return;
+                }
+                await PuppetfileUpdateService.updateModuleVersionAtLine(args.line, args.version);
+        });
+
         // Add all commands to subscriptions
-        context.subscriptions.push(updateAllToSafe, updateAllToLatest, showDependencyTree, clearForgeCache);
+        context.subscriptions.push(updateAllToSafe, updateAllToLatest, showDependencyTree, clearForgeCache, updateModuleVersion);
 
 	// Register hover provider for Puppetfile (pattern-based to avoid duplicates)
 	const hoverProvider = vscode.languages.registerHoverProvider(

--- a/src/puppetForgeService.ts
+++ b/src/puppetForgeService.ts
@@ -150,6 +150,16 @@ export class PuppetForgeService {
     }
 
     /**
+     * Get information for a specific release version
+     * @param moduleName Module name
+     * @param version Version to lookup
+     */
+    public static async getReleaseForVersion(moduleName: string, version: string): Promise<ForgeVersion | null> {
+        const releases = await this.getModuleReleases(moduleName);
+        return releases.find(r => r.version === version) ?? null;
+    }
+
+    /**
      * Get the latest version of a module
      * @param moduleName The full module name (e.g., "puppetlabs/stdlib")
      * @returns Promise with the latest version string

--- a/src/puppetfileUpdateService.ts
+++ b/src/puppetfileUpdateService.ts
@@ -214,6 +214,39 @@ export class PuppetfileUpdateService {
     }
 
     /**
+     * Update a single module line to a specific version
+     * @param lineNumber 1-based line number in the active editor
+     * @param newVersion The version to set
+     */
+    public static async updateModuleVersionAtLine(lineNumber: number, newVersion: string): Promise<void> {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            return;
+        }
+
+        const document = editor.document;
+        const lines = document.getText().split('\n');
+        const lineIndex = lineNumber - 1;
+        if (lineIndex < 0 || lineIndex >= lines.length) {
+            return;
+        }
+
+        const originalLine = lines[lineIndex];
+        const updatedLine = this.updateVersionInLine(originalLine, newVersion);
+        if (updatedLine === originalLine) {
+            return;
+        }
+
+        const range = new vscode.Range(
+            new vscode.Position(lineIndex, 0),
+            new vscode.Position(lineIndex, originalLine.length)
+        );
+        await editor.edit(edit => {
+            edit.replace(range, updatedLine);
+        });
+    }
+
+    /**
      * Generate a summary of update results
      * @param results Array of update results
      * @returns Summary string

--- a/src/test/puppetfileHoverProvider.test.ts
+++ b/src/test/puppetfileHoverProvider.test.ts
@@ -57,6 +57,7 @@ suite('PuppetfileHoverProvider Test Suite', () => {
         // Mock the PuppetForgeService.getModule method
         const originalGetModule = PuppetForgeService.getModule;
         const originalCheckForUpdate = PuppetForgeService.checkForUpdate;
+        const originalGetReleases = PuppetForgeService.getModuleReleases;
         
         const mockForgeModule: ForgeModule = {
             name: 'puppetlabs/stdlib',
@@ -88,6 +89,25 @@ suite('PuppetfileHoverProvider Test Suite', () => {
 
         PuppetForgeService.getModule = async () => mockForgeModule;
         PuppetForgeService.checkForUpdate = async () => mockUpdateInfo;
+        PuppetForgeService.getModuleReleases = async () => [
+            {
+                version: '8.5.0',
+                created_at: '2023-01-01',
+                updated_at: '2023-01-02',
+                downloads: 100,
+                file_size: 1,
+                file_md5: '',
+                file_uri: '',
+                metadata: {
+                    dependencies: [
+                        {
+                            name: 'puppetlabs/concat',
+                            version_requirement: '>= 1.0.0'
+                        }
+                    ]
+                }
+            }
+        ];
 
         try {
             const mockModule = {
@@ -116,6 +136,7 @@ suite('PuppetfileHoverProvider Test Suite', () => {
             // Restore original methods
             PuppetForgeService.getModule = originalGetModule;
             PuppetForgeService.checkForUpdate = originalCheckForUpdate;
+            PuppetForgeService.getModuleReleases = originalGetReleases;
         }
     });
 });


### PR DESCRIPTION
## Summary
- bump version to 0.0.2
- show all available versions in hover and make them clickable
- update dependencies and links to reflect current version
- support updating a single module line
- document new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844b81d15e083258789277d61d40f9e