### PR TITLE
Fix packaging and prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,14 @@ jobs:
     - name: Set output file name
       run: echo "VSIX_FILE=$(npm pkg get name | tr -d '\"')-$(npm pkg get version | tr -d '\"').vsix" >> $GITHUB_ENV
 
+    - name: Set prerelease flag
+      run: |
+        if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+          echo "VSCE_FLAGS=--pre-release" >> "$GITHUB_ENV"
+        fi
+
     - name: Package extension
-      run: npx vsce package --out $VSIX_FILE
+      run: npx vsce package $VSCE_FLAGS --out $VSIX_FILE
 
     - name: Upload release asset
       uses: softprops/action-gh-release@v1

--- a/package.json
+++ b/package.json
@@ -102,5 +102,9 @@
   "dependencies": {
     "axios": "^1.9.0",
     "https-proxy-agent": "^7.0.6"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/example-org/puppetfile-depgraph.git"
   }
 }


### PR DESCRIPTION
## Summary
- add repository URL for vsce
- handle prerelease packaging in release workflow

## Testing
- `npm run lint`
- `npm run compile`
- `npm test`
- `npm run package`

------
https://chatgpt.com/codex/tasks/task_e_6846eb6428588325ae4921fb404f9cb1