### PR TITLE
Fix release versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,12 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    - name: Sync version with tag
+      run: |
+        VERSION="${GITHUB_REF#refs/tags/}"
+        VERSION="${VERSION#v}"
+        npm pkg set version="$VERSION"
+
     - name: Compile TypeScript
       run: npm run compile
 


### PR DESCRIPTION
## Summary
- make release workflow set package.json version from the git tag

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684986cf9a548325a8dc4e6aed436fc5