### PR TITLE
Show Puppetfile name when Git metadata name differs

### DIFF
--- a/src/puppetfileHoverProvider.ts
+++ b/src/puppetfileHoverProvider.ts
@@ -321,7 +321,11 @@ export class PuppetfileHoverProvider implements vscode.HoverProvider {
         const markdown = new vscode.MarkdownString();
         markdown.isTrusted = true;
 
-        markdown.appendMarkdown(`## 📦 ${metadata.name || module.name} [Git]\n\n`);
+        markdown.appendMarkdown(`## 📦 ${module.name} [Git]\n\n`);
+
+        if (metadata.name && metadata.name !== module.name) {
+            markdown.appendMarkdown(`**Metadata Name:** \`${metadata.name}\`\n\n`);
+        }
 
         if (metadata.summary) {
             markdown.appendMarkdown(`*${metadata.summary}*\n\n`);


### PR DESCRIPTION
## Summary
- update Git hover details to always show the Puppetfile module name
- display the name from metadata.json separately when it differs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684996d791848325930d4760c8189c2c