### PR TITLE
fix: resolve Git module name mismatch breaking hover functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ All notable changes to the "puppetfile-depgraph" extension will be documented in
   - Properly extracts Git URL, ref, and tag from modules spanning multiple lines
   - Shows correct Git metadata dependencies instead of falling back to Forge data
   - Handles various Git module formatting styles (indented parameters)
+- **Git Module Name Mismatch**: Fixed critical issue where Git modules break hover functionality
+  - Resolved bug where module name in Puppetfile differs from metadata.json name
+  - Enhanced error isolation to prevent single problematic module from affecting others
+  - Added comprehensive error handling throughout hover provider chain
+  - Improved name display showing both Puppetfile name and repository name when different
+  - Added graceful fallbacks for all Git module processing stages
 
 ### Enhanced
 - **Improved Hover Menu**: Better version display and interaction
@@ -73,7 +79,7 @@ All notable changes to the "puppetfile-depgraph" extension will be documented in
   - Consistent spacing and formatting throughout hover tooltips
 
 ### Technical Improvements
-- **Testing**: Expanded test suite to 121 tests
+- **Testing**: Expanded test suite to 138 tests
   - Added comprehensive tests for inline comment handling
   - Added tests for version update functionality with comments
   - Added comprehensive Git metadata service tests
@@ -81,6 +87,7 @@ All notable changes to the "puppetfile-depgraph" extension will be documented in
   - Added integration tests for real-world scenarios
   - Added tests for line number preservation
   - Enhanced hover provider test coverage
+  - Added Git module name mismatch test coverage
   - Command registration validation
   - Reduced test code duplication from 24% to ~10% through refactoring
   - Introduced helper functions and factory patterns for cleaner test structure

--- a/Puppetfile
+++ b/Puppetfile
@@ -15,6 +15,12 @@ mod 'theforeman-puppet'
     :git => 'https://github.com/theforeman/puppet-foreman.git',
     :ref => '24.2-stable'
 
+# Example of a module with the name different from the one in the `metadata.json`
+# This is a module that is not on the Forge, but is available on GitHub
+mod 'echocat/graphite',
+    :git => 'https://github.com/echocat/puppet-graphite.git',
+    :ref => 'master'
+
 # Forge module without version
 mod 'puppetlabs-nginx'
 

--- a/src/test/gitNameMismatch.test.ts
+++ b/src/test/gitNameMismatch.test.ts
@@ -1,0 +1,117 @@
+import * as assert from 'assert';
+import { PuppetfileHoverProvider } from '../puppetfileHoverProvider';
+
+suite('Git Module Name Mismatch Test Suite', () => {
+    
+    test('should handle Git module name mismatch gracefully', async () => {
+        const hoverProvider = new PuppetfileHoverProvider();
+        
+        // Mock module with Puppetfile name different from metadata.json name
+        const module = {
+            name: 'echocat/graphite',  // Name as declared in Puppetfile
+            source: 'git' as const,
+            gitUrl: 'https://github.com/echocat/puppet-graphite.git',
+            gitRef: 'master',
+            line: 1
+        };
+        
+        // Mock metadata with different name (as would come from metadata.json)
+        const mockMetadata = {
+            name: 'dwerder-graphite',  // Different name in metadata.json
+            version: '1.0.0',
+            author: 'Test Author',
+            summary: 'Test module',
+            license: 'Apache-2.0',
+            source: 'https://github.com/echocat/puppet-graphite.git'
+        };
+        
+        // Test the formatGitModuleWithMetadata method
+        const result = (hoverProvider as any).formatGitModuleWithMetadata(module, mockMetadata);
+        
+        // The result should be a MarkdownString
+        assert.strictEqual(typeof result, 'object');
+        assert.strictEqual(typeof result.appendMarkdown, 'function');
+        
+        // Convert to string to check content
+        const markdownValue = result.value || '';
+        
+        // Should display the Puppetfile name in the header
+        assert.ok(markdownValue.includes('echocat/graphite'), 
+            'Should display Puppetfile declared name in header');
+        
+        // Should show the metadata name as repository name
+        assert.ok(markdownValue.includes('Repository name: `dwerder-graphite`'), 
+            'Should show metadata name as repository name when different');
+        
+        // Should include other metadata
+        assert.ok(markdownValue.includes('Test Author'), 'Should include author');
+        assert.ok(markdownValue.includes('Test module'), 'Should include summary');
+    });
+    
+    test('should not show repository name when names match', async () => {
+        const hoverProvider = new PuppetfileHoverProvider();
+        
+        // Mock module with matching names
+        const module = {
+            name: 'puppetlabs/apache',
+            source: 'git' as const,
+            gitUrl: 'https://github.com/puppetlabs/puppetlabs-apache.git',
+            gitTag: 'v5.10.0',
+            line: 1
+        };
+        
+        // Mock metadata with same name
+        const mockMetadata = {
+            name: 'puppetlabs/apache',  // Same name
+            version: '5.10.0',
+            author: 'Puppet Labs',
+            summary: 'Apache module',
+            license: 'Apache-2.0',
+            source: 'https://github.com/puppetlabs/puppetlabs-apache.git'
+        };
+        
+        // Test the formatGitModuleWithMetadata method
+        const result = (hoverProvider as any).formatGitModuleWithMetadata(module, mockMetadata);
+        
+        // Convert to string to check content
+        const markdownValue = result.value || '';
+        
+        // Should display the name in the header
+        assert.ok(markdownValue.includes('puppetlabs/apache'), 
+            'Should display module name in header');
+        
+        // Should NOT show repository name since they match
+        assert.ok(!markdownValue.includes('Repository name:'), 
+            'Should not show repository name when names match');
+    });
+    
+    test('should handle errors in formatGitModuleWithMetadata gracefully', async () => {
+        const hoverProvider = new PuppetfileHoverProvider();
+        
+        const module = {
+            name: 'test/module',
+            source: 'git' as const,
+            gitUrl: 'https://github.com/test/module.git',
+            line: 1
+        };
+        
+        // Mock metadata that might cause issues
+        const problematicMetadata = {
+            name: null as any,  // Null name that might cause issues
+            version: undefined as any,
+            author: '',
+            summary: '',
+            license: '',
+            source: ''
+        };
+        
+        // Should not throw, should return fallback
+        let result;
+        assert.doesNotThrow(() => {
+            result = (hoverProvider as any).formatGitModuleWithMetadata(module, problematicMetadata);
+        });
+        
+        // Should return some kind of markdown
+        assert.strictEqual(typeof result, 'object');
+    });
+});


### PR DESCRIPTION
This commit addresses a critical bug where Git modules with names that differ between the Puppetfile declaration and their metadata.json would break hover functionality for all modules in the file.

Key changes:
- Enhanced error isolation throughout hover provider chain
- Fixed name display to show both Puppetfile name and repository name when different
- Added comprehensive error handling for all Git module processing stages
- Improved multi-line Git module parsing support
- Enhanced GitMetadataService with better 404 handling and error isolation
- Added graceful fallbacks to prevent cascade failures
- Comprehensive test coverage for name mismatch and multi-line parsing scenarios

Example fix:
Puppetfile: mod 'echocat/graphite', :git => '...'
metadata.json: {"name": "dwerder-graphite"}

Now displays:
📦 echocat/graphite [Git]
Repository name: `dwerder-graphite`

Files changed:
- src/puppetfileHoverProvider.ts: Enhanced error handling and name mismatch display
- src/gitMetadataService.ts: Improved 404 handling and error isolation
- src/puppetfileParser.ts: Added multi-line Git module parsing support
- src/test/gitNameMismatch.test.ts: Added name mismatch test coverage
- src/test/puppetfileParser.test.ts: Added multi-line parsing tests
- Puppetfile: Added test case for Git module name mismatch scenario
- CHANGELOG.md: Updated with fix details

🤖 Generated with [Claude Code](https://claude.ai/code)