### PR TITLE
Fix: Replace String.match() with RegExp.exec() for SonarQube compliance

### DIFF
--- a/src/puppetfileParser.ts
+++ b/src/puppetfileParser.ts
@@ -76,7 +76,7 @@ export class PuppetfileParser {
                     // 2. Is just a module name (no version or git options) and the next line has git options as continuation
                     const isJustModuleName = /^mod\s*['"][^'"]+['"]\s*$/.test(cleanLine);
                     const nextLineHasGitOptions = i + 1 < lines.length && 
-                        lines[i + 1].trim().match(/^\s*:git\s*=>/); // Must start with :git, not just contain it
+                        /^\s*:git\s*=>/.exec(lines[i + 1].trim()) !== null; // Must start with :git, not just contain it
                     
                     
                     if ((cleanLine.endsWith(',') && !cleanLine.includes(';')) || 

--- a/src/services/upgradeDiffCodeLensProvider.ts
+++ b/src/services/upgradeDiffCodeLensProvider.ts
@@ -58,7 +58,7 @@ export class UpgradeDiffCodeLensProvider implements vscode.CodeLensProvider {
             // Look for upgrade comment lines
             if (line.includes('# ↑ UPGRADE:')) {
                 // Extract module name from the comment
-                const match = line.match(/# ↑ UPGRADE: ([^\s]+)/);
+                const match = /# ↑ UPGRADE: ([^\s]+)/.exec(line);
                 if (match) {
                     const moduleName = match[1];
                     

--- a/src/utils/versionParser.ts
+++ b/src/utils/versionParser.ts
@@ -8,7 +8,7 @@ export class VersionParser {
     
     // Handle pessimistic constraint (~>)
     if (constraint.includes('~>')) {
-      const match = constraint.match(/~>\s*(.+)/);
+      const match = /~>\s*(.+)/.exec(constraint);
       if (match) {
         const version = match[1].trim();
         const parts = version.split('.');
@@ -173,8 +173,8 @@ export class VersionParser {
   }
   
   private static compareVersions(v1: string, v2: string): number {
-    const parse1 = v1.match(this.versionRegex);
-    const parse2 = v2.match(this.versionRegex);
+    const parse1 = this.versionRegex.exec(v1);
+    const parse2 = this.versionRegex.exec(v2);
     
     if (!parse1 || !parse2) {
       return v1.localeCompare(v2);

--- a/test/e2e/performance/cachePerformance.test.ts
+++ b/test/e2e/performance/cachePerformance.test.ts
@@ -36,7 +36,7 @@ suite('Performance: Cache Tests', () => {
         moduleName = ModuleNameUtils.toSlashFormat(config.params.module);
       } else if (typeof url === 'string' && url.includes('/modules/')) {
         // Extract from URL like /modules/puppetlabs-stdlib
-        const match = url.match(/\/modules\/([^\/]+)/);
+        const match = /\/modules\/([^\/]+)/.exec(url);
         if (match) {
           moduleName = ModuleNameUtils.toSlashFormat(match[1]);
         }

--- a/test/vscode-test/codeLensProvider.test.ts
+++ b/test/vscode-test/codeLensProvider.test.ts
@@ -34,7 +34,7 @@ suite('Code Lens Provider Integration Tests', () => {
       const lineText = document.lineAt(line).text;
       
       // Update the version in the line
-      const versionMatch = lineText.match(/(['"])([^'"]+)\1\s*,\s*(['"])([^'"]+)\3/);
+      const versionMatch = /(['"])([^'"]+)\1\s*,\s*(['"])([^'"]+)\3/.exec(lineText);
       if (versionMatch) {
         const newLineText = lineText.replace(versionMatch[0], `${versionMatch[1]}${versionMatch[2]}${versionMatch[1]}, ${versionMatch[3]}${newVersion}${versionMatch[3]}`);
         const edit = new vscode.WorkspaceEdit();


### PR DESCRIPTION
## Summary
- Replaces `String.match()` with `RegExp.exec()` throughout the codebase
- Addresses SonarQube code quality recommendation
- Improves code consistency and follows best practices

## Changes
- **Production code**: Updated 4 files to use `RegExp.exec()` instead of `String.match()`
- **Test code**: Updated test files where appropriate, keeping `String.match()` with 'g' flag for counting matches

## Files Modified
- `src/puppetfileParser.ts`
- `src/services/upgradeDiffCodeLensProvider.ts`  
- `src/utils/versionParser.ts`
- `test/vscode-test/codeLensProvider.test.ts`
- `test/e2e/performance/cachePerformance.test.ts`

## Test Plan
- [x] TypeScript compilation passes
- [x] ESLint checks pass
- [x] Unit tests pass
- [x] Integration tests pass
- [x] No functional changes - only syntax improvement

## Context
SonarQube recommends using `RegExp.exec()` over `String.match()` for better performance and clarity when you only need to check if a pattern matches and extract groups.

🤖 Generated with [Claude Code](https://claude.ai/code)